### PR TITLE
session: fix deadlock when interaction responder throws

### DIFF
--- a/src/ferny/session.py
+++ b/src/ferny/session.py
@@ -153,6 +153,11 @@ class Session(SubprocessContext, InteractionResponder):
             assert os.path.exists(self._controlsock)
             self._process = process
         except BaseException:
+            # If we get here because the InteractionResponder raised an
+            # exception then SSH might still be running, and may even attempt
+            # further interactions (ie: 2nd attempt for password).  We already
+            # have our exception and don't need any more info.  Kill it.
+            process.kill()
             await process.wait()
             raise
 


### PR DESCRIPTION
If an interaction responder throws an exception then it successfully aborts the running interaction.  That doesn't always exit SSH, though — in the case of a password prompt, for example, we'll get asked a second time.  In that case, the agent is no longer responding to requests and SSH will wait on us forever at the same time that we're waiting on SSH to quit.

The cleanest and easiest thing to do here is to SIGKILL ssh.  We could close our side of the agent socket, which would prevent the deadlock in this case, but only by causing future agent attempts to fail.  In some cases if SSH keeps asking us (like when getting an invalid response about whether to accept a hostkey) we may end up in a livelock situation.