### PR TITLE
Introduct better detection of errors

### DIFF
--- a/src/ferny/__init__.py
+++ b/src/ferny/__init__.py
@@ -1,11 +1,17 @@
-from .session import Session
+from .errors import AuthenticationError
+from .errors import HostKeyError
+from .errors import SshError
 from .interaction_agent import InteractionAgent
-from .interaction_agent import InteractionResponder
 from .interaction_agent import InteractionError
+from .interaction_agent import InteractionResponder
+from .session import Session
 
 __all__ = [
     'InteractionAgent',
     'InteractionError',
     'InteractionResponder',
     'Session',
+    'AuthenticationError',
+    'HostKeyError',
+    'SshError',
 ]

--- a/src/ferny/__init__.py
+++ b/src/ferny/__init__.py
@@ -1,11 +1,11 @@
 from .session import Session
 from .interaction_agent import InteractionAgent
 from .interaction_agent import InteractionResponder
-from .interaction_agent import SshError
+from .interaction_agent import InteractionError
 
 __all__ = [
     'InteractionAgent',
+    'InteractionError',
     'InteractionResponder',
     'Session',
-    'SshError',
 ]

--- a/src/ferny/errors.py
+++ b/src/ferny/errors.py
@@ -1,0 +1,115 @@
+# ferny - asyncio SSH client library, using ssh(1)
+#
+# Copyright (C) 2023 Allison Karlitskaya <allison.karlitskaya@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import errno
+import re
+import socket
+import os
+
+from typing import ClassVar, Iterable, Match, Optional, Pattern, Tuple
+
+
+class SshError(Exception):
+    PATTERN: ClassVar[Pattern]
+
+    def __init__(self, match: Optional[Match], stderr: str):
+        super().__init__(match.group(0) if match is not None else stderr)
+        self.stderr = stderr
+
+
+class AuthenticationError(SshError):
+    PATTERN = re.compile(r'^([^:]+): Permission denied \(([^()]+)\)\.$', re.M)
+
+    def __init__(self, match: Match, stderr: str):
+        super().__init__(match, stderr)
+        self.destination = match.group(1)
+        self.methods = match.group(2).split(',')
+        self.message = match.group(0)
+
+
+class HostKeyError(SshError):
+    PATTERN = re.compile(r'^Host key verification failed.$', re.M)
+
+
+# Functionality for mapping getaddrinfo()-family error messages to their
+# equivalent Python exceptions.
+def make_gaierror_map() -> Iterable[Tuple[str, int]]:
+    import ctypes
+    libc = ctypes.CDLL(None)
+    libc.gai_strerror.restype = ctypes.c_char_p
+
+    for key in dir(socket):
+        if key.startswith('EAI_'):
+            errnum = getattr(socket, key)
+            yield libc.gai_strerror(errnum).decode('utf-8'), errnum
+
+
+gaierror_map = dict(make_gaierror_map())
+
+
+# Functionality for passing strerror() error messages to their equivalent
+# Python exceptions.
+# There doesn't seem to be an official API for turning an errno into the
+# correct subtype of OSError, and the list that cpython uses is hidden fairly
+# deeply inside of the implementation.  This is basically copied from the
+# ADD_ERRNO() lines in _PyExc_InitState in cpython/Objects/exceptions.c
+oserror_subclass_map = dict((errnum, cls) for cls, errnum in [
+    (BlockingIOError, errno.EAGAIN),
+    (BlockingIOError, errno.EALREADY),
+    (BlockingIOError, errno.EINPROGRESS),
+    (BlockingIOError, errno.EWOULDBLOCK),
+    (BrokenPipeError, errno.EPIPE),
+    (BrokenPipeError, errno.ESHUTDOWN),
+    (ChildProcessError, errno.ECHILD),
+    (ConnectionAbortedError, errno.ECONNABORTED),
+    (ConnectionRefusedError, errno.ECONNREFUSED),
+    (ConnectionResetError, errno.ECONNRESET),
+    (FileExistsError, errno.EEXIST),
+    (FileNotFoundError, errno.ENOENT),
+    (IsADirectoryError, errno.EISDIR),
+    (NotADirectoryError, errno.ENOTDIR),
+    (InterruptedError, errno.EINTR),
+    (PermissionError, errno.EACCES),
+    (PermissionError, errno.EPERM),
+    (ProcessLookupError, errno.ESRCH),
+    (TimeoutError, errno.ETIMEDOUT),
+])
+
+
+def get_exception_for_ssh_stderr(stderr: str) -> Exception:
+    for ssh_cls in [AuthenticationError, HostKeyError]:
+        match = ssh_cls.PATTERN.search(stderr)
+        if match is not None:
+            return ssh_cls(match, stderr)
+
+    before, colon, after = stderr.rpartition(':')
+    if colon and after:
+        potential_strerror = after.strip()
+
+        # DNS lookup errors
+        if potential_strerror in gaierror_map:
+            errnum = gaierror_map[potential_strerror]
+            return socket.gaierror(errnum, stderr)
+
+        # Network connect errors
+        for errnum in errno.errorcode:
+            if os.strerror(errnum) == potential_strerror:
+                os_cls = oserror_subclass_map.get(errnum, OSError)
+                return os_cls(errnum, stderr)
+
+    # No match?  Generic.
+    return SshError(None, stderr)

--- a/src/ferny/interaction_agent.py
+++ b/src/ferny/interaction_agent.py
@@ -26,7 +26,7 @@ from typing import Coroutine, Callable, Dict, List, Optional, TextIO
 logger = logging.getLogger(__name__)
 
 
-class SshError(Exception):
+class InteractionError(Exception):
     pass
 
 
@@ -252,7 +252,7 @@ class InteractionAgent:
                 # We handle fds very carefully to avoid leaking them, even in case of exceptions
                 data, fds, _flags, _addr = recv_fds(self.ours, 4096, 10)
                 if not data:
-                    raise SshError(self.buffer.decode('utf-8').strip())
+                    raise InteractionError(self.buffer.decode('utf-8').strip())
                 self.buffer += data
                 if fds:
                     logger.debug('New interaction request incoming:')

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import shutil
+import socket
 import tempfile
 
 import mockssh
@@ -50,6 +51,21 @@ def runtime_dir():
     d = tempfile.TemporaryDirectory(prefix='ferny-test-run.')
     os.environ['XDG_RUNTIME_DIR'] = d.name
     return d
+
+
+@pytest.mark.asyncio
+async def test_connection_refused():
+    session = ferny.Session()
+    with pytest.raises(ConnectionRefusedError):
+        # hopefully nobody listens on 1...
+        await session.connect('127.0.0.1', port=1)
+
+
+@pytest.mark.asyncio
+async def test_dns_error():
+    session = ferny.Session()
+    with pytest.raises(socket.gaierror):
+        await session.connect('¡invalid hostname!')
 
 
 # these both come from mockssh and aren't interesting to us

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -76,7 +76,7 @@ class TestBasic:
 
     @pytest.mark.asyncio
     async def test_reject_hostkey(self, key_dir, runtime_dir):
-        with pytest.raises(ferny.InteractionError) as raises:
+        with pytest.raises(ferny.HostKeyError) as raises:
             await self.run_test(key_dir, runtime_dir, False, FloatingPointError())
         assert str(raises.value) == 'Host key verification failed.'
 
@@ -92,9 +92,10 @@ class TestBasic:
 
     @pytest.mark.asyncio
     async def test_wrong_passphrase(self, key_dir, runtime_dir):
-        with pytest.raises(ferny.InteractionError) as raises:
+        with pytest.raises(ferny.AuthenticationError) as raises:
             await self.run_test(key_dir, runtime_dir, True, 'xx')
         assert 'Permission denied' in str(raises.value)
+        assert 'publickey' in raises.value.methods
 
     @pytest.mark.asyncio
     async def test_correct_passphrase(self, key_dir, runtime_dir):

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -76,7 +76,7 @@ class TestBasic:
 
     @pytest.mark.asyncio
     async def test_reject_hostkey(self, key_dir, runtime_dir):
-        with pytest.raises(ferny.SshError) as raises:
+        with pytest.raises(ferny.InteractionError) as raises:
             await self.run_test(key_dir, runtime_dir, False, FloatingPointError())
         assert str(raises.value) == 'Host key verification failed.'
 
@@ -92,7 +92,7 @@ class TestBasic:
 
     @pytest.mark.asyncio
     async def test_wrong_passphrase(self, key_dir, runtime_dir):
-        with pytest.raises(ferny.SshError) as raises:
+        with pytest.raises(ferny.InteractionError) as raises:
             await self.run_test(key_dir, runtime_dir, True, 'xx')
         assert 'Permission denied' in str(raises.value)
 


### PR DESCRIPTION
Add some "magic detection" code to make sense of the messages that ssh
writes to its stderr as it exits.  We support mapping OSError-type
errors for network failures, gaierror-type errors for DNS problems, as
well as a couple of ssh-specific errors for hostkey or
authentication-related problems.
