### PR TITLE
session: improve feature detection

### DIFF
--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -53,6 +53,20 @@ def runtime_dir():
     return d
 
 
+def test_feature_detection():
+    # should be case-insensitive, and pass
+    assert ferny.session.has_feature('userknownhostsfile')
+    assert ferny.session.has_feature('UserKnownHostsFile')
+
+    # yummy, but probably never exists
+    assert not ferny.session.has_feature('usersconehostsfile')
+    assert not ferny.session.has_feature('UserSconeHostsFile')
+
+    # requires a specific value
+    assert not ferny.session.has_feature('StrictHostKeyChecking')
+    assert ferny.session.has_feature('StrictHostKeyChecking', 'yes')
+
+
 @pytest.mark.asyncio
 async def test_connection_refused():
     session = ferny.Session()


### PR DESCRIPTION
The idea to use `ssh -G` to get a list of supported features only works for features which have non-`NULL` default values.  If a particular configuration option is `NULL` (ie: `none`) then it is skipped in the output.

This happens to be the case for KnownHostsCommand, which means that our attempt to detect it was always coming back false, hitting the fallback path and the workaround in the tests, but failing in real-life use.

A quick read of the code of OpenSSH seems to suggest that there's no other way to get a list of valid options, so change our approach: we can query a specific option by attempting to set it and see if we get an error or not.

Put this under tests so we know that it's working properly.  This will also detect possible future changes to the behaviour of ssh.