### PR TITLE
test: Check large environment

### DIFF
--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -130,3 +130,12 @@ class TestBasic:
     @pytest.mark.asyncio
     async def test_correct_passphrase(self, key_dir, runtime_dir):
         await self.run_test(key_dir, runtime_dir, True, 'passphrase')
+
+    @pytest.mark.asyncio
+    async def test_large_env(self, key_dir, runtime_dir):
+        orig = os.environ.copy()
+        os.environ['BLABBERMOUTH'] = 'bla' * 10000
+        try:
+            await self.run_test(key_dir, runtime_dir, True, 'passphrase')
+        finally:
+            os.environ = orig


### PR DESCRIPTION
With a bunch of `$XDG_DATA_DIRS`, long `$PATH` and `$LS_COLORS` it is    
easy to exceed 4KB in the environment. Before commit 85c805c61a13, this    
made the agent (and most of the tests) crash with    
    
    SyntaxError: unterminated string literal (detected at line 1)    
    
when reading the request.    
    
Add a unit test with a large environment variable to ensure that this    
does not regress again.    