### PR TITLE
interaction_client: Support cancelling through EOF on stdin

### DIFF
--- a/src/ferny/interaction_client.py
+++ b/src/ferny/interaction_client.py
@@ -2,11 +2,12 @@
 
 import array
 import os
+import select
 import socket
 import sys
 
 
-def interact(stdout_fd: int, stderr_fd: int, *data: object) -> int:
+def interact(stdin_fd: int, stdout_fd: int, stderr_fd: int, *data: object) -> int:
     packet = f'\0ferny\0{repr(data)}'.encode('utf-8')
 
     ours, theirs = socket.socketpair()
@@ -16,12 +17,27 @@ def interact(stdout_fd: int, stderr_fd: int, *data: object) -> int:
         fds = [theirs.fileno(), stdout_fd]
         stderr.sendmsg([packet], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", fds))])
 
+    # check if stdin is an actual communication channel, as opposed to e.g. /dev/null which is immediately EOF
+    res = select.select([stdin_fd], [], [], 0)[0]
+    if stdin_fd in res:
+        try:
+            have_stdin = os.read(stdin_fd, 1) != b''
+        except OSError:
+            have_stdin = False
+    else:
+        have_stdin = True
+
     with ours:
-        return int(ours.recv(16) or b'1')
+        # wait until we either get a result on ours, or the caller closes stdin to signal cancelling
+        ready = select.select([stdin_fd, ours], [], [])
+        if not have_stdin or ours in ready[0]:
+            return int(ours.recv(16) or b'1')
+        else:
+            return 1
 
 
 def main() -> None:
-    sys.exit(interact(sys.stdout.fileno(), sys.stderr.fileno(), sys.argv, dict(os.environ)))
+    sys.exit(interact(sys.stdin.fileno(), sys.stdout.fileno(), sys.stderr.fileno(), sys.argv, dict(os.environ)))
 
 
 if __name__ == '__main__':

--- a/src/ferny/interaction_client.py
+++ b/src/ferny/interaction_client.py
@@ -6,7 +6,7 @@ import socket
 import sys
 
 
-def interact(stderr_fd: int, stdout_fd: int, *data: object) -> int:
+def interact(stdout_fd: int, stderr_fd: int, *data: object) -> int:
     packet = f'\0ferny\0{repr(data)}'.encode('utf-8')
 
     ours, theirs = socket.socketpair()
@@ -21,7 +21,7 @@ def interact(stderr_fd: int, stdout_fd: int, *data: object) -> int:
 
 
 def main() -> None:
-    sys.exit(interact(2, 1, sys.argv, dict(os.environ)))
+    sys.exit(interact(sys.stdout.fileno(), sys.stderr.fileno(), sys.argv, dict(os.environ)))
 
 
 if __name__ == '__main__':

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,0 +1,61 @@
+import os
+import socket
+import threading
+
+# for older Python versions
+from ferny.interaction_agent import recv_fds
+from ferny.interaction_client import interact
+
+
+def test_basic():
+    our_err, their_err = socket.socketpair()
+    our_out, their_out = os.pipe()
+
+    interact_res = None
+
+    def run_interact():
+        nonlocal interact_res
+        interact_res = interact(their_out, their_err.fileno(), ['some', 'data'], {'answer': 42})
+
+    t_interact = threading.Thread(target=run_interact)
+    t_interact.start()
+    os.close(their_out)
+
+    # receive the two fds from the client
+    msg, [res_fd, res_out], _flags, _addr = recv_fds(our_err, 4096, 2)
+    their_err.close()
+
+    # send result
+    os.write(res_fd, b'7')
+    os.close(res_fd)
+    t_interact.join()
+
+    assert msg == b"\x00ferny\x00(['some', 'data'], {'answer': 42})"
+    assert interact_res == 7
+
+
+def test_send_no_result():
+    our_err, their_err = socket.socketpair()
+    our_out, their_out = os.pipe()
+
+    interact_res = None
+
+    def run_interact():
+        nonlocal interact_res
+        interact_res = interact(their_out, their_err.fileno(), 'data')
+
+    t_interact = threading.Thread(target=run_interact)
+    t_interact.start()
+    os.close(their_out)
+
+    # receive the two fds from the client
+    msg, [res_fd, _res_out], _flags, _addr = recv_fds(our_err, 4096, 2)
+    their_err.close()
+
+    # don't send a result
+    os.close(res_fd)
+    t_interact.join()
+
+    assert msg == b"\x00ferny\x00('data',)"
+    # default result is 1
+    assert interact_res == 1


### PR DESCRIPTION
This is how cockpit's channels work -- closing them (when the user    
cancels an authentication dialog, for example) closes the spawned    
program's stdin and SIGTERMs it. Our interaction agent never sees    
SIGTERM, as that goes to the program that spawned it (like sudo or ssh),    
and as sudo ignores SIGTERM, the stdin EOF is our only chance to get    
signalled about "I want to cancel".    

---

This is the second half for fixing https://github.com/cockpit-project/cockpit/issues/18676