### PR TITLE
Improve the ferny interaction protocol

### DIFF
--- a/doc/interaction-protocol.md
+++ b/doc/interaction-protocol.md
@@ -1,0 +1,122 @@
+# ferny "Interaction" protocol
+
+ferny includes an askpass client program and agent.  The agent is implemented
+as a class which runs as part of the Python program using ferny and the client
+program is invoked as the `SSH_ASKPASS` program.
+
+The interaction occurs via `stderr`.  Before `ssh` is spawned, a `socketpair()`
+is created in the `AF_UNIX` domain, and one half of it is passed as the
+`stderr` of the `ssh` authentication process.  At that point, the agent starts
+attempting to receive messages on its end of the socket.
+
+## Protocol details
+
+This section is subject to change at absolutely any time.  You should only use
+`ferny.InteractionAgent` and `ferny.interaction_client` found in the same
+package.  Mixing and matching from different versions will likely break.
+Implementing it for yourself will probably break, unless you're vendoring ferny
+and running thorough regression tests on updates.
+
+### "Wire format"
+
+In general, unstructured data in the form of messages which `ssh` writes to its
+stderr is collected.  In addition, "commands" can be received via structured
+messages.
+
+These commands are essentially asynchronous, one-directional remote procedure
+calls.  There is no support for completion notification or return values
+(although it's possible to add it at a higher level — see `ferny.askpass`,
+below, for an example).
+
+Each command has:
+ - a command name (such as `ferny.askpass`)
+ - zero or more arguments: values of any `repr()`-able type
+ - zero or more file descriptors
+
+Additionally, each command receives the unstructured stderr contents printed
+before the command was sent.  This is useful for things like askpass
+interactions which may want to present dialogs which also contain the previous
+error messages (eg. "Permission denied, please try again.").
+
+There are two ways to send commands, which are conceptually equivalent, but
+only one of these methods supports passing file descriptors.
+
+#### "Local" mechanism — can send file descriptors
+
+These messages are always sent as a single nul ('\0') byte accompanied
+by a number of file descriptors.  The first file descriptor is always the
+reader end of a pipe from which the content of the command and arguments should
+be read (until EOF).  It's a utf-8 string in the following form:
+
+```python
+    repr((command_name, tuple(args)))
+```
+
+The remaining file descriptors are the 'zero or more file descriptors' which
+are part of the command being sent.
+
+The "local" way of sending commands should be preferred whenever it is
+available — even if sending a command without file descriptors.
+
+#### "Remote" mechanism — can't send file descriptors
+
+These messages are sent in the following form, as utf-8:
+
+```python
+    '\0ferny\0 + repr((command_name, tuple(args))) + '\0\0\n'
+```
+
+The command being sent has no possibility of receiving file descriptors if this
+form is used, but this form can be sent in situations where stderr is (no
+longer) a unix socket.  This might be useful for sending commands from remote
+hosts over SSH, for example.
+
+Note: with remote commands, extra care must be taken to ensure that the sender
+of the command is the same version of ferny as running locally, and not a
+version of ferny found on the remote host.  You should be using something like
+`beiboot` for providing the program to the remote.
+
+## Built-in commands
+
+ferny contains a couple of commands implemented internally:
+
+### `ferny.askpass`
+
+This is the primary askpass interaction that occurs when the `ferny-askpass`
+helper is invoked (usually by `ssh`, `sudo`, or similar).
+
+The command expects to receive two arguments:
+ - `sys.argv` of `ferny-askpass` as a tuple or list
+ - `os.environ` of `ferny-askpass` as a dictionary
+
+The command expects to receive two file descriptors:
+ - the "status" file descriptor (see below)
+ - the "stdout" file descriptor to which the answer will be written
+
+Since the command receives file descriptors, it can only be sent using the
+"local" mechanism described above.
+
+The "status" file descriptor is a socket.  As long as it's open on both ends,
+the interaction is considered to be running.  Either side can close it (or
+half-close it) to signal that the interaction should end.
+
+`ferny-askpass` will never write anything to it, so if it ever polls readable
+then it means it's been closed.  This means that `ferny-askpass` has exited and
+the interaction is over.  This can happen if `ferny-askpass` is killed (which
+ssh sometimes does, for example).
+
+When the interaction agent wishes to signal `ferny-askpass` to exit, it should
+write an integer to the status socket and then close it.  This integer is used
+as the exit status of `ferny-askpass`.  If no integer is passed, the exit
+status is 1.
+
+### `ferny.end`
+
+This is command signals the interaction agent to exit.  It accepts no
+parameters and no file descriptors.
+
+## Custom commands
+
+It's possible to implement your own commands.  If ferny receives a command that
+it doesn't recognize, it will invoke the `.do_custom_command()` method on your
+`InteractionResponder`.

--- a/src/ferny/interaction_client.py
+++ b/src/ferny/interaction_client.py
@@ -1,27 +1,41 @@
 #!/usr/bin/python3
 
 import array
+import io
 import os
 import socket
 import sys
 
+from typing import Dict, List, Sequence
 
-def interact(stderr_fd: int, stdout_fd: int, *data: object) -> int:
-    packet = f'\0ferny\0{repr(data)}'.encode('utf-8')
 
+def command(stderr_fd: int, command: str, *args: object, fds: Sequence[int] = ()) -> None:
+    cmd_read, cmd_write = [io.open(*end) for end in zip(os.pipe(), 'rw')]
+
+    with cmd_write:
+        with cmd_read:
+            with socket.fromfd(stderr_fd, socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                fd_array = array.array('i', (cmd_read.fileno(), *fds))
+                sock.sendmsg([b'\0'], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fd_array)])
+
+        cmd_write.write(repr((command, args)))
+
+
+def askpass(stderr_fd: int, stdout_fd: int, args: List[str], env: Dict[str, str]) -> int:
     ours, theirs = socket.socketpair()
 
-    with theirs, socket.fromfd(stderr_fd, socket.AF_UNIX, socket.SOCK_STREAM) as stderr:
-        # socket.send_fds(stderr, [packet], [theirs.fileno(), stdout_fd])
-        fds = [theirs.fileno(), stdout_fd]
-        stderr.sendmsg([packet], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", fds))])
+    with theirs:
+        command(stderr_fd, 'ferny.askpass', args, env, fds=(theirs.fileno(), stdout_fd))
 
     with ours:
         return int(ours.recv(16) or b'1')
 
 
 def main() -> None:
-    sys.exit(interact(2, 1, sys.argv, dict(os.environ)))
+    if len(sys.argv) == 1:
+        command(2, 'ferny.end', [])
+    else:
+        sys.exit(askpass(2, 1, sys.argv, dict(os.environ)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make the interaction protocol clearer and more robust, and document it.

This is an incompatible protocol change: instead of writing the command as in-band data in the stderr socket, we send a pipe as an extra fd and write the command over that.  As in-band data we send a single '\0'.

The main reason for this change was the existence of a bug in the current approach: in general, it's not possible to reliably know which in-band data was sent along with which control message, except in the case that only a single byte is sent.

Sending only a single byte of in-band data also avoids another somewhat more pedestrian issue: in case the socket buffer was full, and we received a signal during the sendmsg() call in `ferny-askpass`, we'd have to handle the possibility of a partial retransmission.  If we send a single byte, then the write either succeeds or it doesn't — and if it doesn't, then `SA_RESTART` (or failing that, Python) will retry the syscall.

At the same time as making this change, take the chance to add a clearer conceptual boundary between the idea of sending "commands" and all of the extra handling that we need to do to implement askpass.  Also, remove the conceptual boundary between "local" and "remote" commands.

`InteractionAgent` is now more or less responsible for implementing the low-level "sending commands" layer, and `InteractionResponder` is responsible for the implementation of the commands (including askpass). The `Interaction` helper class no longer exists — most of what it contained and did is now contained entirely in the _askpass_command() function.