### PR TITLE
Add API to make it easier to use ferny-askpass

### DIFF
--- a/src/ferny/__init__.py
+++ b/src/ferny/__init__.py
@@ -1,12 +1,16 @@
 from .errors import AuthenticationError
 from .errors import HostKeyError
 from .errors import SshError
+from .interaction_agent import COMMAND_TEMPLATE
 from .interaction_agent import InteractionAgent
 from .interaction_agent import InteractionError
 from .interaction_agent import InteractionResponder
+from .interaction_agent import temporary_askpass
+from .interaction_agent import write_askpass_to_tmpdir
 from .session import Session
 
 __all__ = [
+    'COMMAND_TEMPLATE',
     'InteractionAgent',
     'InteractionError',
     'InteractionResponder',
@@ -14,4 +18,6 @@ __all__ = [
     'AuthenticationError',
     'HostKeyError',
     'SshError',
+    'temporary_askpass',
+    'write_askpass_to_tmpdir'
 ]


### PR DESCRIPTION
The documentation advises that external projects should avoid implementing their own version of the protocol, but fails to provide convenient mechanisms for accessing ferny's implementation.

Provide two new APIs:

 - a `COMMAND_TEMPLATE` which should be used for constructing ferny commands using the "remote" mechanism.  The API is really weird, but at least it's something like an API, and if we need to change things, we can break it in an obvious way.

 - a function and a context manager to support getting an executable copy of `ferny-askpass` installed into a temporary directory for use from ssh or sudo.