### PR TITLE
agent: add another new way to get the client code

### DIFF
--- a/src/ferny/__init__.py
+++ b/src/ferny/__init__.py
@@ -1,5 +1,6 @@
 from .errors import AuthenticationError, ChangedHostKeyError, HostKeyError, SshError, UnknownHostKeyError
 from .interaction_agent import (
+    BEIBOOT_GADGETS,
     COMMAND_TEMPLATE,
     InteractionAgent,
     InteractionError,
@@ -10,6 +11,7 @@ from .interaction_agent import (
 from .session import Session
 
 __all__ = [
+    'BEIBOOT_GADGETS',
     'COMMAND_TEMPLATE',
     'InteractionAgent',
     'InteractionError',

--- a/src/ferny/interaction_agent.py
+++ b/src/ferny/interaction_agent.py
@@ -34,6 +34,19 @@ logger = logging.getLogger(__name__)
 COMMAND_RE = re.compile(b'\0ferny\0([^\n]*)\0\0\n')
 COMMAND_TEMPLATE = '\0ferny\0{(command, args)!r}\0\0\n'
 
+BEIBOOT_GADGETS = {
+    "command": fr"""
+        import sys
+        def command(command, *args):
+            sys.stderr.write(f{COMMAND_TEMPLATE!r})
+            sys.stderr.flush()
+    """,
+    "end": r"""
+        def end():
+            command('ferny.end')
+    """,
+}
+
 
 class InteractionError(Exception):
     pass


### PR DESCRIPTION
Previously we were exporting the somewhat awkward-to-use COMMAND_TEMPLATE which beiboot was importing for its own purposes.  This was always an awkward API and beiboot importing it directly caused problems with vendoring beiboot and ferny together in a third package (Cockpit).

Instead of COMMAND_TEMPLATE, provide a new BEIBOOT_GADGETS dictionary to be used in the upcoming beiboot support for "gadgets" as part of constructing the first-stage bootloader.