### PR TITLE
ssh_errors: ignore \r output by SSH

### DIFF
--- a/src/ferny/ssh_askpass.py
+++ b/src/ferny/ssh_askpass.py
@@ -61,7 +61,6 @@ class SSHAskpassPrompt(AskpassPrompt):
 
         for pattern in self._extra_patterns:
             extra_match = re.search(with_helpers(pattern), messages, re.M)
-            print(extra_match, with_helpers(pattern), messages)
             if extra_match is not None:
                 self.__dict__.update(extra_match.groupdict())
 

--- a/src/ferny/ssh_errors.py
+++ b/src/ferny/ssh_errors.py
@@ -100,6 +100,8 @@ oserror_subclass_map = dict((errnum, cls) for cls, errnum in [
 
 
 def get_exception_for_ssh_stderr(stderr: str) -> Exception:
+    stderr = stderr.replace('\r\n', '\n')  # fix line separators
+
     # check for the specific error messages first, then for generic SshHostKeyError
     for ssh_cls in [SshAuthenticationError, SshChangedHostKeyError, SshUnknownHostKeyError, SshHostKeyError]:
         match = ssh_cls.PATTERN.search(stderr)


### PR DESCRIPTION
For some strange reasons possibly related to RFC compliance, ssh(1) outputs its stderr messages with a carriage return added at the end of each line, just before the newline.

Strip that out before we try to match the error messages, or nothing is going to match.

Drop a stray debugging print() while we're at it.