### PR TITLE
transport: call Protocol.connection_made ASAP

### DIFF
--- a/src/ferny/transport.py
+++ b/src/ferny/transport.py
@@ -153,11 +153,8 @@ class FernyTransport(asyncio.Transport, asyncio.SubprocessProtocol):
             assert self._stdin_transport is not None
             assert self._stdout_transport is not None
 
-            # Time to go live — ask the InteractionAgent to start processing
-            # stderr and tell our protocol that we're ready to receive data.
+            # Ask the InteractionAgent to start processing stderr.
             self._agent.start()
-            logger.debug('calling connection_made(%r, %r)', self, self._protocol)
-            self._protocol.connection_made(self)
 
         self._exec_task.add_done_callback(exec_completed)
 
@@ -238,6 +235,9 @@ class FernyTransport(asyncio.Transport, asyncio.SubprocessProtocol):
 
         stderr_transport = transport.get_pipe_transport(2)
         assert stderr_transport is None
+
+        logger.debug('calling connection_made(%r, %r)', self, self._protocol)
+        self._protocol.connection_made(self)
 
     def connection_lost(self, exc: 'Exception | None') -> None:
         logger.debug('connection_lost(%r, %r)', self, exc)


### PR DESCRIPTION
It's been observed that in certain real-life scenarios we can start receiving data via `.pipe_data_received()` before `.subprocess_exec()` completes.  That happens when there are enough async callbacks in flight that the spawned subprocess starts writing to its stdout before we have a chance to deliver the result of `.subprocess_exec()`.

This is problematic, because we were deferring calling the `.connection_made()` of our connected Protocol until after the exec call returned.  This gap made it possible for us to start delivering data to the Protocol before connecting to it.

Instead of waiting for the async exec call to finish running, call connection_made() on the Protocol as soon as our own connection_made() is called.  There was really no reason not to do it that way in the first place — and the assumption that it was equivalent to calling it at the end of `.connection_made()` proved incorrect.