### PR TITLE
Fixes for OpenSSH 9.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,3 +37,21 @@ jobs:
 
       - name: Run unit tests
         run: PYTHONPATH=src python3 -m pytest --color=yes
+
+  debian:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container: docker.io/debian:unstable
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Install runtime and test dependencies
+        run: |
+          apt-get update
+          apt-get install -y python3-pytest-asyncio python3-pip openssh-client
+          pip3 install --break-system-packages asyncssh==2.13.2
+
+      - name: Run unit tests
+        # FIXME: test_cancel_askpass hangs forever
+        run: python3 -m pytest -k 'not test_cancel_askpass'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: CI
 on:
   push:
   pull_request:
+  schedule:
+    - cron: 0 4 * * MON,FRI
 
 jobs:
   fedora:

--- a/src/ferny/session.py
+++ b/src/ferny/session.py
@@ -37,7 +37,7 @@ PR_SET_PDEATHSIG = 1
 @functools.lru_cache()
 def has_feature(feature: str, teststr: str = 'x') -> bool:
     try:
-        subprocess.check_output(['ssh', f'-o{feature} {teststr}', '-G', '-'], stderr=subprocess.DEVNULL)
+        subprocess.check_output(['ssh', f'-o{feature} {teststr}', '-G', 'nonexisting'], stderr=subprocess.DEVNULL)
         return True
     except subprocess.CalledProcessError:
         return False

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -94,7 +94,7 @@ async def test_connection_refused(runtime_dir: pathlib.Path) -> None:
 @pytest.mark.asyncio
 async def test_dns_error(runtime_dir: pathlib.Path) -> None:
     session = ferny.Session()
-    with pytest.raises(socket.gaierror):
+    with pytest.raises((socket.gaierror, ferny.ssh_errors.SshError)):
         await session.connect('¡invalid hostname!')
 
 


### PR DESCRIPTION
See https://github.com/cockpit-project/bots/pull/5733. When updating ferny locally to this version, it fixes at least `TestSuperuserDashboard.test`. I'll do a test run in a cockpit PR to validate all of [this mess](https://cockpit-logs.us-east-1.linodeobjects.com/pull-5733-20231229-230014-db95e17a-debian-stable-expensive-cockpit-project-cockpit/log.html): https://github.com/cockpit-project/cockpit/pull/19799