### PR TITLE
workflows: Add CI for CentOS stream 10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,17 +20,23 @@ jobs:
       - name: Run unit tests
         run: python3 -m pytest --color=yes --cov
 
-  c9s:
+  centos:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - stream9
+          - stream10-development
     timeout-minutes: 10
-    container: quay.io/centos/centos:stream9
+    container: quay.io/centos/centos:${{ matrix.tag }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
 
       - name: Install distro runtime and test dependencies
         run: |
-          dnf install -y openssh-clients python3-pip python3-cryptography python3-pytest
+          dnf install -y openssh-clients python3-pip python3-cryptography
 
       - name: Install pip test dependencies
         run: pip3 install pytest-asyncio asyncssh


### PR DESCRIPTION
CentOS 10 doesn't package pytest any more, so install it via pip. That works on CentOS 9 as well.

---

This was triggered by https://github.com/cockpit-project/bots/pull/7001 : RHEL 10's openssh [adds an additional failure message](https://gitlab.com/redhat/centos-stream/rpms/openssh/-/commit/84ad70de575a2a241a3739c1f5aa1ae1d3cbb59e) which breaks parsing in cockpit. ferny is fine, but let's keep it that way!

