### PR TITLE
Pick connection errors from "ssh:" lines only

### DIFF
--- a/src/ferny/ssh_errors.py
+++ b/src/ferny/ssh_errors.py
@@ -113,6 +113,14 @@ def get_exception_for_ssh_stderr(stderr: str) -> Exception:
         if match is not None:
             return ssh_cls(match, stderr)
 
+    # chop off lines at the end which are not from ssh, like from
+    # https://gitlab.com/redhat/centos-stream/rpms/openssh/-/commit/84ad70de57
+    lines = stderr.splitlines()
+    while lines and not lines[-1].startswith('ssh: '):
+        lines.pop()
+    if lines:  # only do that if there is *any* message from ssh:
+        stderr = '\n'.join(lines)
+
     before, colon, after = stderr.rpartition(':')
     if colon and after:
         potential_strerror = after.strip()


### PR DESCRIPTION
RHEL 10's ssh recently started to add an extra bit of output after
connection errors [1]. These will now look like this:

```
$ ssh -p 987 localhost
ssh: connect to host localhost port 987: Connection refused

You can find some explanations for typical errors at this link:
	    https://red.ht/support_rhel_ssh
```

This ought to only happen if stderr is a tty [2], but in the meantime
we need to ignore that: if there is any "ssh: .." line in the output,
chop off everything after it.

This fixes `test_connection_refused` and `test_ssh_error` with
openssh-9.9p1-2.el10, see [3]

[1] https://gitlab.com/redhat/centos-stream/rpms/openssh/-/commit/84ad70de57
[2] https://issues.redhat.com/browse/RHEL-63061
[3] https://github.com/cockpit-project/bots/pull/7001

----

~This builds on top of #30  , so marking as blocked.~

Note that the current c10s-development container cannot yet "see" the new openssh revision -2. To fully test, you need to run
```
dnf update https://composes.stream.centos.org/stream-10/development/latest-CentOS-Stream/compose/BaseOS/x86_64/os/Packages/openssh-9.9p1-2.el10.x86_64.rpm https://composes.stream.centos.org/stream-10/development/latest-CentOS-Stream/compose/BaseOS/x86_64/os/Packages/openssh-clients-9.9p1-2.el10.x86_64.rpm
```
I did that locally.
