### PR TITLE
Stop hardcoding libc soname

### DIFF
--- a/src/ferny/session.py
+++ b/src/ferny/session.py
@@ -29,7 +29,7 @@ from typing import Mapping, Sequence
 from . import ssh_errors
 from .interaction_agent import InteractionAgent, InteractionError, InteractionHandler, write_askpass_to_tmpdir
 
-prctl = ctypes.cdll.LoadLibrary('libc.so.6').prctl
+prctl = ctypes.CDLL(None).prctl
 logger = logging.getLogger(__name__)
 PR_SET_PDEATHSIG = 1
 


### PR DESCRIPTION
ia64/alpha has SONAME "libc.so.6.1"

`None` works because Python is linked against libc, so the symbol is already in our address space.

See https://github.com/cockpit-project/cockpit/issues/21396
